### PR TITLE
add the way of installing through Carthage

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,13 @@ CocoaPods' support for swift is still pre-released, and requires your iOS deploy
 [sudo] gem install cocoapods --pre
 ```
 
+Carthage
+---
+You can install `ReactiveUI` through Carthage adding the following to your Cartfile:
+
+~~~
+github 'zhxnlai/ReactiveUI'
+~~~
 
 Usage
 ---


### PR DESCRIPTION
Though installing through Carthage has already merged  ( https://github.com/zhxnlai/ReactiveUI/pull/2 ), there is no modification in README.md.
